### PR TITLE
Fix error at startup

### DIFF
--- a/analytics-listeners/src/main/java/org/exoplatform/analytics/listener/portal/UserAnalyticsEventListener.java
+++ b/analytics-listeners/src/main/java/org/exoplatform/analytics/listener/portal/UserAnalyticsEventListener.java
@@ -3,13 +3,18 @@ package org.exoplatform.analytics.listener.portal;
 import static org.exoplatform.analytics.utils.AnalyticsUtils.*;
 
 import org.exoplatform.analytics.model.StatisticData;
+import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.organization.User;
-import org.exoplatform.services.organization.UserEventListener;
+import org.exoplatform.services.organization.impl.NewUserEventListener;
 
-public class UserAnalyticsEventListener extends UserEventListener {
+public class UserAnalyticsEventListener extends NewUserEventListener {
 
   private ThreadLocal<Long> operationStartTime = new ThreadLocal<>();
-
+  
+  public UserAnalyticsEventListener(InitParams params) throws Exception {
+    super(params);
+  }
+  
   @Override
   public void preSave(User user, boolean isNew) throws Exception {
     operationStartTime.set(System.currentTimeMillis());


### PR DESCRIPTION
Before this fix, when platform start with fresh db, we have an error :
```
2021-03-12 11:12:09,020 | ERROR | Failed start Organization Service org.exoplatform.services.organization.idm.PicketLinkIDMOrganizationServiceImpl, probably because of configuration error. Error occurs when initialize org.exoplatform.services.organization.OrganizationDatabaseInitializer [o.e.s.o.i.PicketLinkIDMOrganizationServiceImpl<Catalina-startStop-1>]
java.lang.RuntimeException: Failed start Organization Service org.exoplatform.services.organization.idm.PicketLinkIDMOrganizationServiceImpl, probably because of configuration error. Error occurs when initialize org.exoplatform.services.organization.OrganizationDatabaseInitializer
  at org.exoplatform.services.organization.BaseOrganizationService.start(BaseOrganizationService.java:91) ~[exo.core.component.organization.api-6.2.x-SNAPSHOT.jar:6.2.x-SNAPSHOT]

```
This commit rollback the impacted modification