### PR TITLE
TASK-41723 Fix Active users portlet

### DIFF
--- a/analytics-api/src/main/java/org/exoplatform/analytics/model/chart/ChartData.java
+++ b/analytics-api/src/main/java/org/exoplatform/analytics/model/chart/ChartData.java
@@ -30,14 +30,14 @@ public class ChartData implements Serializable {
   public void addAggregationResult(ChartAggregationResult aggregationResult, int index, boolean replaceIfExists) {
     int existingIndex = aggregationResults.indexOf(aggregationResult);
     if (existingIndex < 0) {
-      if (index < 0) {
+      if (index < 0 || index >= aggregationResults.size()) {
         aggregationResults.add(aggregationResult);
       } else {
         aggregationResults.add(index, aggregationResult);
       }
     } else if (replaceIfExists) {
-      aggregationResults.remove(index);
-      if (index < 0) {
+      aggregationResults.remove(existingIndex);
+      if (index < 0 || index >= aggregationResults.size()) {
         aggregationResults.add(aggregationResult);
       } else {
         aggregationResults.add(index, aggregationResult);


### PR DESCRIPTION
Fix Array index out of bound error by using the 'existingIndex' (detected index of existing aggregation) instead 'index' (index where to add aggregation result)