### PR TITLE
Task-46943: Analytics - spaces and users analytics - The button parameters is hidden

### DIFF
--- a/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/AnalyticsTableApplication.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/AnalyticsTableApplication.vue
@@ -25,7 +25,7 @@
           :title="$t('analytics.settings')"
           class="d-none d-sm-inline text-header-title my-auto"
           @click="$refs.tableSettingDrawer.open()">
-          <v-icon>mdi-settings</v-icon>
+          <v-icon>fa-cog</v-icon>
         </v-btn>
         <analytics-table-setting
           ref="tableSettingDrawer"


### PR DESCRIPTION
The button parameters in spaces and users analytics page is hidden, to fix it we need to update icon library.