### PR TITLE
TASK-47234 Add Tooling to measure Vue applications performances

### DIFF
--- a/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/analytics-ui-watchers-configuration.xml
+++ b/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/analytics-ui-watchers-configuration.xml
@@ -3,6 +3,18 @@
   for more details. You should have received a copy of the GNU Lesser General Public License along with this software; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF site: http://www.fsf.org. -->
 <configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd" xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
 
+  <component>
+    <key>FrontEndPerformancesTracking</key>
+    <type>org.exoplatform.container.ExtendedPropertyConfigurator</type>
+    <init-params>
+      <properties-param>
+        <name>FrontEndPerformancesTracking</name>
+        <description>Front End Applications Performances Tracking Feature enablement flag</description>
+        <property name="exo.feature.FrontEndPerformancesTracking.enabled" value="${exo.feature.FrontEndPerformancesTracking.enabled:false}" />
+      </properties-param>
+    </init-params>
+  </component>
+
   <external-component-plugins>
     <target-component>org.exoplatform.analytics.api.service.AnalyticsService</target-component>
     <component-plugin>

--- a/analytics-webapps/src/main/webapp/groovy/UIPageDisplayStatisticCollection.gtmpl
+++ b/analytics-webapps/src/main/webapp/groovy/UIPageDisplayStatisticCollection.gtmpl
@@ -2,38 +2,15 @@
   import org.exoplatform.commons.api.settings.ExoFeatureService;
   import org.exoplatform.commons.utils.HTMLEntityEncoder;
   import org.apache.commons.lang.StringUtils;
+  import org.exoplatform.commons.utils.PropertyManager;
 
   def rcontext = _ctx.getRequestContext() ;
   def featureService = uicomponent.getApplicationComponent(ExoFeatureService.class);
 %>
 <script type="text/javascript">
-<% if (featureService.isActiveFeature('ServerTimeTracking')) { %>
-  eXo.env.portal.onLoadCallbacks.push(() => {
-    const requestStartTime = <%=rcontext.getAttribute("requestStartTime")%>;
-    const nowDate = Date.now();
-    if (requestStartTime && nowDate > requestStartTime) {
-      if (eXo.developing) {
-        console.debug(`Page displayed within: \${(nowDate - requestStartTime)} milliseconds`);
-      }
-      const statisticMessage = {
-        name: 'pageUIDisplay',
-        operation: 'pageUIDisplay',
-        userName: eXo.env.portal.userName,
-        spaceId: eXo.env.portal.spaceId,
-        parameters: {
-          duration: (nowDate - requestStartTime),
-          portalName: eXo.env.portal.portalName,
-          portalUri: window.location.pathname,
-          pageUri: window.location.pathname,
-          pageTitle: `<%=HTMLEntityEncoder.getInstance().encode(rcontext.getTitle())%>`,
-          pageUri: `<%=HTMLEntityEncoder.getInstance().encode(rcontext.getNodePath())%>`,
-          applicationNames: `<%=StringUtils.join(uicomponent.getPortletNames(), ",")%>`,
-        },
-      };
-      window.setTimeout(() => {
-        document.dispatchEvent(new CustomEvent('exo-statistic-message', {detail: statisticMessage}));
-      }, 500);
-    }
+<% if (featureService.isActiveFeature('FrontEndPerformancesTracking') || PropertyManager.isDevelopping()) { %>
+  eXo.env.portal.requestStartTime = <%=rcontext.getAttribute("requestStartTime")%>;
+  eXo.env.portal.pageTitle = `<%=HTMLEntityEncoder.getInstance().encode(rcontext.getTitle())%>`;
+  eXo.env.portal.applicationNames = `<%=StringUtils.join(uicomponent.getPortletNames(), ",")%>`;
 <% } %>
-  });
 </script>

--- a/analytics-webapps/src/main/webapp/js/statistic-collection.js
+++ b/analytics-webapps/src/main/webapp/js/statistic-collection.js
@@ -1,5 +1,5 @@
 function() {
-  return {
+  const api = {
     init : function (settings, watchers) {
       if (settings && watchers && !this.watchers) {
         this.watchers = watchers;
@@ -109,4 +109,149 @@ function() {
       }
     },
   };
+
+  eXo.env.portal.onLoadCallbacks.push(() => {
+    const nowDate = Date.now();
+    if (eXo.env.portal.requestStartTime && nowDate > eXo.env.portal.requestStartTime) {
+      const isMobile = navigator.userAgentData.mobile;
+      const loadingTime = nowDate - eXo.env.portal.requestStartTime;
+      const loadingTimeStyle = (loadingTime > (isMobile && 5000 || 3000)) && 'color:red;font-weight:bold;' || 'color:green;font-weight:bold;';
+      if (eXo.developing) {
+        console.warn(`%cPage displayed within: %c${loadingTime} %cms`,
+          'font-weight:bold;',
+          loadingTimeStyle,
+          '');
+      }
+      window.setTimeout(() => {
+        api.sendMessage({
+          name: 'pageUIDisplay',
+          operation: 'pageUIDisplay',
+          userName: eXo.env.portal.userName,
+          spaceId: eXo.env.portal.spaceId,
+          parameters: {
+            duration: loadingTime,
+            portalName: eXo.env.portal.portalName,
+            portalUri: eXo.env.server.portalBaseURL,
+            pageUri: window.location.pathname,
+            pageTitle: eXo.env.portal.pageTitle,
+            pageUri: eXo.env.portal.selectedNodeUri,
+            applicationNames: eXo.env.portal.applicationNames,
+            isMobile,
+          },
+        });
+      }, 500);
+    }
+  });
+
+  require(['SHARED/vue'], () => {
+    if (eXo.env.portal.requestStartTime) {
+      eXo.env.portal.loadingAppsStartTime = {};
+      document.addEventListener('vue-app-loading-start', event => {
+        const appName = event && event.detail;
+        if (eXo.env.portal.requestStartTime && appName && !eXo.env.portal.loadingAppsStartTime[appName]) {
+          const now = Date.now();
+          eXo.env.portal.loadingAppsStartTime[appName] = {
+            start: now,
+          };
+          const startLoadingTime = now - eXo.env.portal.requestStartTime;
+          const startTimeStyle = startLoadingTime > 3000 && 'color:red;font-weight:bold;' || 'color:green;font-weight:bold;';
+          if (eXo.developing) {
+            // eslint-disable-next-line no-console
+            console.debug(`App %c${appName}%c Start Loading at: %c${startLoadingTime} %cms`,
+              'font-weight:bold;',
+              '',
+              startTimeStyle,
+              '');
+          }
+          api.sendMessage();
+        }
+      });
+      document.addEventListener('vue-app-loading-end', event => {
+        const appName = event && event.detail;
+        if (!appName) {
+          // eslint-disable-next-line no-console
+          console.warn('Missing Application name, please verify that "data" attribute near Vue.create is of type object');
+        } else if (eXo.env.portal.requestStartTime && eXo.env.portal.loadingAppsStartTime[appName]) {
+          const start = eXo.env.portal.loadingAppsStartTime[appName].start;
+          delete eXo.env.portal.loadingAppsStartTime[appName];
+          const end = Date.now();
+          const startLoadingTime = start - eXo.env.portal.requestStartTime;
+          const endLoadingTime = end - eXo.env.portal.requestStartTime;
+          const durationLoadingTime = end - start;
+          const startTimeStyle = startLoadingTime > 3000 && 'color:red;font-weight:bold;' || 'color:green;font-weight:bold;';
+          const endTimeStyle = endLoadingTime > 3000 && 'color:red;font-weight:bold;' || 'color:green;font-weight:bold;';
+          const durationTimeStyle = durationLoadingTime > 1000 && 'color:red;font-weight:bold;' || 'color:green;font-weight:bold;';
+          if (eXo.developing) {
+            // eslint-disable-next-line no-console
+            console.debug(`App %c${appName}%c
+               Started at: %c${startLoadingTime} %cms
+               End at: %c${endLoadingTime} %cms
+               Duration : %c${durationLoadingTime} %cms`, 
+            'font-weight:bold;',
+            '',
+            startTimeStyle,
+            '',
+            endTimeStyle,
+            '',
+            durationTimeStyle,
+            '');
+          }
+
+          window.setTimeout(() => {
+            api.sendMessage({
+              name: 'pageUIDisplay',
+              operation: 'applicationUIDisplay',
+              userName: eXo.env.portal.userName,
+              spaceId: eXo.env.portal.spaceId,
+              parameters: {
+                duration: durationLoadingTime,
+                portalName: eXo.env.portal.portalName,
+                portalUri: eXo.env.server.portalBaseURL,
+                pageUri: window.location.pathname,
+                pageTitle: eXo.env.portal.pageTitle,
+                pageUri: eXo.env.portal.selectedNodeUri,
+                applicationName: appName,
+                startLoadingTime: startLoadingTime,
+                endLoadingTime: endLoadingTime,
+              },
+            });
+          }, 500);
+
+          if (!Object.keys(eXo.env.portal.loadingAppsStartTime).length) {
+            window.setTimeout(() => {
+              if (!eXo.env.portal.loadingAppsFinished && !Object.keys(eXo.env.portal.loadingAppsStartTime).length) {
+                eXo.env.portal.loadingAppsFinished = true;
+                if (eXo.developing) {
+                  // eslint-disable-next-line no-console
+                  console.warn(`Overall %cpage applications%c finished loading at : %c${endLoadingTime} %cms`, 
+                    'font-weight:bold;',
+                    '',
+                    endTimeStyle,
+                    '');
+                }
+                api.sendMessage({
+                  name: 'pageUIDisplay',
+                  operation: 'pageFullUIDisplay',
+                  userName: eXo.env.portal.userName,
+                  spaceId: eXo.env.portal.spaceId,
+                  parameters: {
+                    duration: endLoadingTime,
+                    portalName: eXo.env.portal.portalName,
+                    portalUri: eXo.env.server.portalBaseURL,
+                    pageUri: window.location.pathname,
+                    pageTitle: eXo.env.portal.pageTitle,
+                    pageUri: eXo.env.portal.selectedNodeUri,
+                    applicationNames: eXo.env.portal.applicationNames,
+                    isMobile: navigator.userAgentData.mobile,
+                  },
+                });
+              }
+            }, 1000);
+          }
+        }
+      });
+    }
+  });
+
+  return api;
 }();


### PR DESCRIPTION
This new Tool will intercept the new Global Vue applications lifecycle events.
In Dev Mode Or when a Feature flag `FrontEndPerformancesTracking` is enabled, some analytics data will be sent to serever for:
1. Each Application Metrics :
*  Start Loading time comparing to first user click
*  End Loading time comparing to first user click
* Duration of Loading of the application
2. First Page `onload` trigger event duration
3. All Vue applications display duration (= equivalent to Full Page display)

In Dev Mode Only, some additional  `debug` & `warn` entries will be displayed for helping developers measuring their apps performances.