### PR TITLE
Task-48231 : No Notes Analytics for analytics app (#151)

### DIFF
--- a/analytics-listeners/src/main/resources/conf/portal/configuration.xml
+++ b/analytics-listeners/src/main/resources/conf/portal/configuration.xml
@@ -170,7 +170,7 @@
     </component-plugin>
   </external-component-plugins>
 
-  <external-component-plugins profiles="wiki">
+  <external-component-plugins profiles="notes">
     <target-component>org.exoplatform.wiki.service.WikiService</target-component>
     <component-plugin>
       <name>WikiPageListener</name>


### PR DESCRIPTION
when adding or modifying or deleting notes the analytics module does not collect the information for these operations, and this is because of the profile name in configuration.xml, so my solution is to modify the profile name