### PR TITLE
Task-48469 : Missing data in creation date column in space analytics page

### DIFF
--- a/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/portal-configuration.xml
+++ b/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/portal-configuration.xml
@@ -47,7 +47,7 @@
               <boolean>${exo.analytics.portalConfig.metadata.override:true}</boolean>
             </field>
             <field name="importMode">
-              <string>${exo.analytics.portalConfig.metadata.importmode:insert}</string>
+              <string>${exo.analytics.portalConfig.metadata.importmode:merge}</string>
             </field>
             <field name="predefinedOwner">
               <collection type="java.util.HashSet">


### PR DESCRIPTION
Prior this change,the creation date column in the space analysis page is always empty.