### PR TITLE
TASK-48470 : fixed Missing data in Connections count column in analytics table

### DIFF
--- a/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/portal-configuration.xml
+++ b/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/portal-configuration.xml
@@ -47,7 +47,7 @@
               <boolean>${exo.analytics.portalConfig.metadata.override:true}</boolean>
             </field>
             <field name="importMode">
-              <string>${exo.analytics.portalConfig.metadata.importmode:insert}</string>
+              <string>${exo.analytics.portalConfig.metadata.importmode:merge}</string>
             </field>
             <field name="predefinedOwner">
               <collection type="java.util.HashSet">

--- a/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/portal/portal/global/pages.xml
+++ b/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/portal/portal/global/pages.xml
@@ -488,8 +488,7 @@
                             "periodIndependent":false,
                             "aggregation":{
                                "sortDirection":"desc",
-                               "field":"doc['timestamp'].date.dayOfYear",
-                               "type":"CARDINALITY"
+                               "type":"COUNT"
                             }
                          },
                          "sortable":true,


### PR DESCRIPTION
Before this fix , when opening the analytics table , the columns creation date and connections count are missing due to the fact that the appropriate filter is not applied to fetch data with elasticsearch so i fixed this by adding the correct filter to be used by the elastic search service 