### PR TITLE
Task-48469 : Missing data in creation date column in space analytics page.

### DIFF
--- a/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/portal/portal/global/pages.xml
+++ b/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/portal/portal/global/pages.xml
@@ -603,7 +603,16 @@
                    "columns":[
                       {
                          "title":"analytics.creationDate",
-                         "spaceField":"createdTime",
+                         "previousPeriod":false,
+                         "valueAggregation":{
+                               "aggregation":{
+                                 "sortDirection":"desc",
+                                 "field":"spaceCreatedTime",
+                                 "type":"MAX",
+                               },
+                               "periodIndependent":false
+                         },
+                         "sortable":true,
                          "dataType":"date"
                       },
                       {


### PR DESCRIPTION
Prior this change,the creation date column in the space analysis page is always empty.