### PR TITLE
Task-48469 : Missing data in creation date column in space analytics page

### DIFF
--- a/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/portal/portal/global/pages.xml
+++ b/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/portal/portal/global/pages.xml
@@ -609,7 +609,7 @@
                                  "field":"spaceCreatedTime",
                                  "type":"MAX",
                                },
-                               "periodIndependent":false
+                               "periodIndependent":true
                          },
                          "sortable":true,
                          "dataType":"date"


### PR DESCRIPTION
Creation date column in spaces analytics page should be period independent.