### PR TITLE
TASK-46944 : fixed displaying wrong week number

### DIFF
--- a/analytics-api/src/main/java/org/exoplatform/analytics/model/filter/aggregation/AnalyticsAggregation.java
+++ b/analytics-api/src/main/java/org/exoplatform/analytics/model/filter/aggregation/AnalyticsAggregation.java
@@ -107,7 +107,6 @@ public class AnalyticsAggregation implements Serializable, Cloneable {
     Locale userLocale = StringUtils.isBlank(lang) ? Locale.getDefault() : new Locale(lang);
     LocalDateTime dateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(timestamp), zoneId);
     DateTimeFormatter dateFormatter = null;
-    String dateFormated = "";
     switch (interval) {
       case YEAR_INTERVAL:
         dateFormatter = YEAR_DATE_FORMATTER;
@@ -130,14 +129,11 @@ public class AnalyticsAggregation implements Serializable, Cloneable {
       default:
         dateFormatter = DAY_DATE_FORMATTER;
     }
+    String dateFormated =  dateTime.format(dateFormatter.withLocale(userLocale));
     if (interval.equals(WEEK_INTERVAL)){
-       dateFormated = dateTime.format(dateFormatter.withLocale(userLocale)) ;
        String[] date = dateFormated.split("-");
-       dateFormated = date[1]+"-"+date[0];
+       dateFormated = date[1] + "-" + date[0];
     }
-    else {
-      dateFormated =  dateTime.format(dateFormatter.withLocale(userLocale));
-      }
     return dateFormated;
   }
 

--- a/analytics-api/src/main/java/org/exoplatform/analytics/model/filter/aggregation/AnalyticsAggregation.java
+++ b/analytics-api/src/main/java/org/exoplatform/analytics/model/filter/aggregation/AnalyticsAggregation.java
@@ -45,7 +45,7 @@ public class AnalyticsAggregation implements Serializable, Cloneable {
 
   public static final DateTimeFormatter DAY_DATE_FORMATTER     = DateTimeFormatter.ofPattern("d MMM uuuu");
 
-  public static final DateTimeFormatter WEEK_DATE_FORMATTER    = DateTimeFormatter.ofPattern("'W'w uuuu");
+  public static final DateTimeFormatter WEEK_DATE_FORMATTER    = DateTimeFormatter.ISO_WEEK_DATE;
 
   public static final DateTimeFormatter HOUR_DATE_FORMATTER    = DateTimeFormatter.ofPattern("hh a, d MMM uuuu");
 
@@ -107,6 +107,7 @@ public class AnalyticsAggregation implements Serializable, Cloneable {
     Locale userLocale = StringUtils.isBlank(lang) ? Locale.getDefault() : new Locale(lang);
     LocalDateTime dateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(timestamp), zoneId);
     DateTimeFormatter dateFormatter = null;
+    String dateFormated = "";
     switch (interval) {
       case YEAR_INTERVAL:
         dateFormatter = YEAR_DATE_FORMATTER;
@@ -129,7 +130,15 @@ public class AnalyticsAggregation implements Serializable, Cloneable {
       default:
         dateFormatter = DAY_DATE_FORMATTER;
     }
-    return dateTime.format(dateFormatter.withLocale(userLocale));
+    if (interval.equals(WEEK_INTERVAL)){
+       dateFormated = dateTime.format(dateFormatter.withLocale(userLocale)) ;
+       String[] date = dateFormated.split("-");
+       dateFormated = date[1]+"-"+date[0];
+    }
+    else {
+      dateFormated =  dateTime.format(dateFormatter.withLocale(userLocale));
+      }
+    return dateFormated;
   }
 
   @Override


### PR DESCRIPTION
in analytics when choosing  'X AXIS' tab in the top menu and check 'Per week' it displays a wrong week number (actual week number +1)
since the DateTimeFormatter.ofPattern(' 'W' w uuuu') returns  week-based date without an offset
fixed by formatting date with 'BASIC_ISO_DATE' that return the right week number without offset