### PR TITLE
Task-48652: Add missing data in creation date users column

### DIFF
--- a/analytics-api/src/main/java/org/exoplatform/analytics/utils/AnalyticsUtils.java
+++ b/analytics-api/src/main/java/org/exoplatform/analytics/utils/AnalyticsUtils.java
@@ -12,7 +12,6 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.exoplatform.social.core.identity.model.Profile;
 import org.json.*;
 
 import org.exoplatform.analytics.api.service.StatisticDataQueueService;
@@ -363,16 +362,6 @@ public class AnalyticsUtils {
   public static long getCurrentUserIdentityId() {
     ConversationState currentState = ConversationState.getCurrent();
     return getUserIdentityId(currentState);
-  }
-
-  public static long getUserCreatedDate(String username) {
-    IdentityManager identityManager = CommonsUtils.getService(IdentityManager.class);
-    Identity identity = identityManager.getOrCreateIdentity(ActivityStream.ORGANIZATION_PROVIDER_ID, username);
-    long userCreatedDate = 0;
-    if(identity != null && identity.getProfile() != null ) {
-      userCreatedDate = identity.getProfile().getCreatedTime();
-    }
-    return userCreatedDate;
   }
 
   public static boolean isUnkownUser(String username) {

--- a/analytics-api/src/main/java/org/exoplatform/analytics/utils/AnalyticsUtils.java
+++ b/analytics-api/src/main/java/org/exoplatform/analytics/utils/AnalyticsUtils.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.social.core.identity.model.Profile;
 import org.json.*;
 
 import org.exoplatform.analytics.api.service.StatisticDataQueueService;
@@ -362,6 +363,16 @@ public class AnalyticsUtils {
   public static long getCurrentUserIdentityId() {
     ConversationState currentState = ConversationState.getCurrent();
     return getUserIdentityId(currentState);
+  }
+
+  public static long getUserCreatedDate(String username) {
+    IdentityManager identityManager = CommonsUtils.getService(IdentityManager.class);
+    Identity identity = identityManager.getOrCreateIdentity(ActivityStream.ORGANIZATION_PROVIDER_ID, username);
+    long userCreatedDate = 0;
+    if(identity != null && identity.getProfile() != null ) {
+      userCreatedDate = identity.getProfile().getCreatedTime();
+    }
+    return userCreatedDate;
   }
 
   public static boolean isUnkownUser(String username) {

--- a/analytics-listeners/src/main/java/org/exoplatform/analytics/listener/social/AnalyticsProfileListener.java
+++ b/analytics-listeners/src/main/java/org/exoplatform/analytics/listener/social/AnalyticsProfileListener.java
@@ -51,6 +51,7 @@ public class AnalyticsProfileListener extends ProfileListenerPlugin {
     statisticData.setOperation(operation);
     statisticData.setUserId(getCurrentUserIdentityId());
     statisticData.addParameter(FIELD_SOCIAL_IDENTITY_ID, getUserIdentityId(username));
+    statisticData.addParameter("userCreatedDate", getUserCreatedDate(username));
     return statisticData;
   }
 

--- a/analytics-listeners/src/main/java/org/exoplatform/analytics/listener/social/AnalyticsProfileListener.java
+++ b/analytics-listeners/src/main/java/org/exoplatform/analytics/listener/social/AnalyticsProfileListener.java
@@ -3,6 +3,7 @@ package org.exoplatform.analytics.listener.social;
 import static org.exoplatform.analytics.utils.AnalyticsUtils.*;
 
 import org.exoplatform.analytics.model.StatisticData;
+import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.model.AvatarAttachment;
 import org.exoplatform.social.core.profile.ProfileLifeCycleEvent;
 import org.exoplatform.social.core.profile.ProfileListenerPlugin;
@@ -45,13 +46,14 @@ public class AnalyticsProfileListener extends ProfileListenerPlugin {
   }
 
   private StatisticData buildStatisticData(String operation, String username) {
+    Identity identity = getIdentity(username);
     StatisticData statisticData = new StatisticData();
     statisticData.setModule("social");
     statisticData.setSubModule("profile");
     statisticData.setOperation(operation);
     statisticData.setUserId(getCurrentUserIdentityId());
-    statisticData.addParameter(FIELD_SOCIAL_IDENTITY_ID, getUserIdentityId(username));
-    statisticData.addParameter("userCreatedDate", getUserCreatedDate(username));
+    statisticData.addParameter(FIELD_SOCIAL_IDENTITY_ID, identity == null ? 0 : Long.parseLong(identity.getId()));
+    statisticData.addParameter("userCreatedDate", identity != null && identity.getProfile() != null ? identity.getProfile().getCreatedTime() : 0);
     return statisticData;
   }
 

--- a/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/portal/portal/global/pages.xml
+++ b/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/portal/portal/global/pages.xml
@@ -452,7 +452,16 @@
                    "columns":[
                       {
                          "title":"analytics.creationDate",
-                         "userField":"createdDate",
+                         "previousPeriod":false,
+                         "valueAggregation":{
+                            "periodIndependent":true,
+                            "aggregation":{
+                               "sortDirection":"desc",
+                               "field":"userCreatedDate",
+                               "type":"MAX"
+                            }
+                         },
+                         "sortable":true,
                          "dataType":"date"
                       },
                       {


### PR DESCRIPTION
Before this fix, the creation date column on analytics utilisateur is empty.
This fix will implement the creation date statistics value on analytics utilisateur.