### PR TITLE
TASK-48842 : fix Wrong Connections count number when user connects many time in the same day

### DIFF
--- a/analytics-listeners/src/main/java/org/exoplatform/analytics/listener/portal/LoginAnalyticsListener.java
+++ b/analytics-listeners/src/main/java/org/exoplatform/analytics/listener/portal/LoginAnalyticsListener.java
@@ -3,18 +3,23 @@ package org.exoplatform.analytics.listener.portal;
 import static org.exoplatform.analytics.utils.AnalyticsUtils.addStatisticData;
 import static org.exoplatform.analytics.utils.AnalyticsUtils.getUserIdentityId;
 
+import org.apache.commons.lang.time.DateUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.analytics.model.StatisticData;
 import org.exoplatform.services.listener.*;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
+import org.exoplatform.services.organization.idm.UserImpl;
 import org.exoplatform.services.security.ConversationRegistry;
 import org.exoplatform.services.security.ConversationState;
+
+import java.util.Date;
 
 @Asynchronous
 public class LoginAnalyticsListener extends Listener<ConversationRegistry, ConversationState> {
   private static final Log LOG = ExoLogger.getLogger(LoginAnalyticsListener.class);
+  private static final String LOGIN = "login";
 
   @Override
   public void onEvent(Event<ConversationRegistry, ConversationState> event) throws Exception {
@@ -25,11 +30,15 @@ public class LoginAnalyticsListener extends Listener<ConversationRegistry, Conve
       return;
     }
     boolean isLogin = isLogin(event);
-    String operation = isLogin ? "login" : "logout";
-
+    String operation = isLogin ? LOGIN : "logout";
+    UserImpl profile = (UserImpl) state.getAttribute("UserProfile");
+    Date lastLoginTime = profile.getLastLoginTime();
+    if (operation.equals(LOGIN) && DateUtils.isSameDay(new Date(), lastLoginTime) && !profile.getCreatedDate().equals(lastLoginTime)){
+      return;
+    }
     StatisticData statisticData = new StatisticData();
     statisticData.setModule("portal");
-    statisticData.setSubModule("login");
+    statisticData.setSubModule(LOGIN);
     statisticData.setOperation(operation);
     statisticData.setUserId(userId);
     addStatisticData(statisticData);

--- a/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTable.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTable.vue
@@ -2,7 +2,7 @@
   <v-data-table
     ref="dataTable"
     :headers="headers"
-    :items="items"
+    :items="itemsToDisplay"
     :items-per-page="pageSize"
     :loading="loading"
     :options.sync="options"
@@ -103,6 +103,17 @@ export default {
     sortDirection: 'desc',
   }),
   computed: {
+    itemsToDisplay() {
+      const lastConnectionColumn = this.headers.find(head => head.text === this.$t('analytics.lastConnection')) ? this.headers.find(head => head.text === this.$t('analytics.lastConnection')).value : null;
+      if (lastConnectionColumn && !this.loading && this.items && this.items.length > 0 ) {
+        this.items.forEach((itemColumn) => {
+          if (itemColumn.column0.identity !== null){
+            itemColumn[lastConnectionColumn].value = itemColumn.column0.identity.lastLoginTime ;
+          }
+        });
+      }
+      return this.items;
+    },
     hasMore() {
       return (this.loading && this.limit > this.pageSize) || this.limit === this.items.length;
     },


### PR DESCRIPTION
when a user login each time the login listener indexes a new distinct doc to the ES.
while counting the number of connections it gets all the login docs since are DISTINCT 
fixed by avoiding adding a doc if he has already logged in the same day
fixed getting lastConnectionTime table field from the already retrieved identity