### PR TITLE
Task-48652: Add missing data in creation date users column (#166)

### DIFF
--- a/analytics-listeners/src/main/java/org/exoplatform/analytics/listener/social/AnalyticsProfileListener.java
+++ b/analytics-listeners/src/main/java/org/exoplatform/analytics/listener/social/AnalyticsProfileListener.java
@@ -3,6 +3,8 @@ package org.exoplatform.analytics.listener.social;
 import static org.exoplatform.analytics.utils.AnalyticsUtils.*;
 
 import org.exoplatform.analytics.model.StatisticData;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.social.core.model.AvatarAttachment;
 import org.exoplatform.social.core.profile.ProfileLifeCycleEvent;
 import org.exoplatform.social.core.profile.ProfileListenerPlugin;
@@ -45,12 +47,17 @@ public class AnalyticsProfileListener extends ProfileListenerPlugin {
   }
 
   private StatisticData buildStatisticData(String operation, String username) {
+    Identity identity = getIdentity(OrganizationIdentityProvider.NAME, username);
+    if (identity == null) {
+      return null;
+    }
     StatisticData statisticData = new StatisticData();
     statisticData.setModule("social");
     statisticData.setSubModule("profile");
     statisticData.setOperation(operation);
-    statisticData.setUserId(getCurrentUserIdentityId());
-    statisticData.addParameter(FIELD_SOCIAL_IDENTITY_ID, getUserIdentityId(username));
+    statisticData.setUserId(Long.parseLong(identity.getId()));
+    statisticData.addParameter(FIELD_SOCIAL_IDENTITY_ID, Long.parseLong(identity.getId()));
+    statisticData.addParameter("userCreatedDate", identity.getProfile() != null ? identity.getProfile().getCreatedTime() : 0);
     return statisticData;
   }
 

--- a/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/portal/portal/global/pages.xml
+++ b/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/portal/portal/global/pages.xml
@@ -452,7 +452,16 @@
                    "columns":[
                       {
                          "title":"analytics.creationDate",
-                         "userField":"createdDate",
+                         "previousPeriod":false,
+                         "valueAggregation":{
+                            "periodIndependent":true,
+                            "aggregation":{
+                               "sortDirection":"desc",
+                               "field":"userCreatedDate",
+                               "type":"MAX"
+                            }
+                         },
+                         "sortable":true,
                          "dataType":"date"
                       },
                       {


### PR DESCRIPTION
Before this fix, the creation date column on analytics users is empty.
This fix will implement the creation date statistics value on analytics utilisateur.