### PR TITLE
MAINT-50781: Fix calculating the offset of previous and current selected period in connected users percentage report

### DIFF
--- a/analytics-api/pom.xml
+++ b/analytics-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.exoplatform.addons.analytics</groupId>
     <artifactId>analytics-parent</artifactId>
-    <version>1.2.x-SNAPSHOT</version>
+    <version>1.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>analytics-api</artifactId>
   <name>eXo Analytics - API</name>

--- a/analytics-api/src/main/java/org/exoplatform/analytics/model/filter/AnalyticsPercentageFilter.java
+++ b/analytics-api/src/main/java/org/exoplatform/analytics/model/filter/AnalyticsPercentageFilter.java
@@ -213,15 +213,7 @@ public class AnalyticsPercentageFilter extends AbstractAnalyticsFilter {
     xAxisAggregation.setMinBound(getPreviousAnalyticsPeriod().getFromInMS());
     xAxisAggregation.setMaxBound(getCurrentAnalyticsPeriod().getToInMS() - 1000);
     xAxisAggregation.setUseBounds(true);
-    if (customPeriod != null) {
-      long diffInDays = customPeriod.getDiffInDays();
-      if (diffInDays > 0) {
-        long offset = (xAxisAggregation.getMinBound() / 86400000l) % diffInDays;
-        if (offset > 0) {
-          xAxisAggregation.setOffset(offset + "d");
-        }
-      }
-    } else {
+    if (customPeriod == null) {
       AnalyticsPeriodType analyticsPeriodType = getAnalyticsPeriodType();
       if (analyticsPeriodType != null && analyticsPeriodType.getOffset(xAxisAggregation.getMinBound()) > 0) {
         long offset = analyticsPeriodType.getOffset(xAxisAggregation.getMinBound());

--- a/analytics-listeners/pom.xml
+++ b/analytics-listeners/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.exoplatform.addons.analytics</groupId>
     <artifactId>analytics-parent</artifactId>
-    <version>1.2.x-SNAPSHOT</version>
+    <version>1.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>analytics-listeners</artifactId>
   <name>eXo Analytics - Listeners</name>

--- a/analytics-packaging/pom.xml
+++ b/analytics-packaging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.exoplatform.addons.analytics</groupId>
     <artifactId>analytics-parent</artifactId>
-    <version>1.2.x-SNAPSHOT</version>
+    <version>1.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>analytics-packaging</artifactId>
   <packaging>pom</packaging>

--- a/analytics-services/pom.xml
+++ b/analytics-services/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.exoplatform.addons.analytics</groupId>
     <artifactId>analytics-parent</artifactId>
-    <version>1.2.x-SNAPSHOT</version>
+    <version>1.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>analytics-services</artifactId>
   <name>eXo Analytics - Services</name>

--- a/analytics-webapps/pom.xml
+++ b/analytics-webapps/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.exoplatform.addons.analytics</groupId>
     <artifactId>analytics-parent</artifactId>
-    <version>1.2.x-SNAPSHOT</version>
+    <version>1.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>analytics-webapps</artifactId>
   <packaging>war</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
   <groupId>org.exoplatform.addons.analytics</groupId>
   <artifactId>analytics-parent</artifactId>
-  <version>1.2.x-SNAPSHOT</version>
+  <version>1.2.x-maintenance-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo Analytics - Parent POM</name>
   <description>eXo Analytics Addon</description>
@@ -29,24 +29,24 @@
   </scm>
   <properties>
     <!-- 3rd party libraries versions -->
-    <org.exoplatform.social.version>6.3.x-SNAPSHOT</org.exoplatform.social.version>
-    <org.exoplatform.platform-ui.version>6.3.x-SNAPSHOT</org.exoplatform.platform-ui.version>
-    <addon.exo.jcr.version>6.3.x-SNAPSHOT</addon.exo.jcr.version>
-    <addon.exo.ecms.version>6.3.x-SNAPSHOT</addon.exo.ecms.version>
-    <addon.exo.tasks.version>3.3.x-SNAPSHOT</addon.exo.tasks.version>
-    <addon.exo.web-conferencing.version>2.3.x-SNAPSHOT</addon.exo.web-conferencing.version>
-    <addon.exo.layout-management.version>1.3.x-SNAPSHOT</addon.exo.layout-management.version>
-    <addon.exo.digital-workplace.version>1.3.x-SNAPSHOT</addon.exo.digital-workplace.version>
-    <addon.exo.news.version>2.3.x-SNAPSHOT</addon.exo.news.version>
-    <addon.exo.onlyoffice.version>2.3.x-SNAPSHOT</addon.exo.onlyoffice.version>
-    <addon.exo.chat.version>3.3.x-SNAPSHOT</addon.exo.chat.version>
-    <addon.exo.agenda.version>1.2.x-SNAPSHOT</addon.exo.agenda.version>
-    <addon.exo.kudos.version>2.3.x-SNAPSHOT</addon.exo.kudos.version>
-    <addon.exo.perk-store.version>2.3.x-SNAPSHOT</addon.exo.perk-store.version>
-    <addon.exo.wallet.version>2.3.x-SNAPSHOT</addon.exo.wallet.version>
-    <addon.exo.gamification.version>2.3.x-SNAPSHOT</addon.exo.gamification.version>
-    <addon.exo.push-notifications.version>2.3.x-SNAPSHOT</addon.exo.push-notifications.version>
-    <addon.exo.app-center.version>2.3.x-SNAPSHOT</addon.exo.app-center.version>
+    <org.exoplatform.social.version>6.3.x-maintenance-SNAPSHOT</org.exoplatform.social.version>
+    <org.exoplatform.platform-ui.version>6.3.x-maintenance-SNAPSHOT</org.exoplatform.platform-ui.version>
+    <addon.exo.jcr.version>6.3.x-maintenance-SNAPSHOT</addon.exo.jcr.version>
+    <addon.exo.ecms.version>6.3.x-maintenance-SNAPSHOT</addon.exo.ecms.version>
+    <addon.exo.tasks.version>3.3.x-maintenance-SNAPSHOT</addon.exo.tasks.version>
+    <addon.exo.web-conferencing.version>2.3.x-maintenance-SNAPSHOT</addon.exo.web-conferencing.version>
+    <addon.exo.layout-management.version>1.3.x-maintenance-SNAPSHOT</addon.exo.layout-management.version>
+    <addon.exo.digital-workplace.version>1.3.x-maintenance-SNAPSHOT</addon.exo.digital-workplace.version>
+    <addon.exo.news.version>2.3.x-maintenance-SNAPSHOT</addon.exo.news.version>
+    <addon.exo.onlyoffice.version>2.3.x-maintenance-SNAPSHOT</addon.exo.onlyoffice.version>
+    <addon.exo.chat.version>3.3.x-maintenance-SNAPSHOT</addon.exo.chat.version>
+    <addon.exo.agenda.version>1.2.x-maintenance-SNAPSHOT</addon.exo.agenda.version>
+    <addon.exo.kudos.version>2.3.x-maintenance-SNAPSHOT</addon.exo.kudos.version>
+    <addon.exo.perk-store.version>2.3.x-maintenance-SNAPSHOT</addon.exo.perk-store.version>
+    <addon.exo.wallet.version>2.3.x-maintenance-SNAPSHOT</addon.exo.wallet.version>
+    <addon.exo.gamification.version>2.3.x-maintenance-SNAPSHOT</addon.exo.gamification.version>
+    <addon.exo.push-notifications.version>2.3.x-maintenance-SNAPSHOT</addon.exo.push-notifications.version>
+    <addon.exo.app-center.version>2.3.x-maintenance-SNAPSHOT</addon.exo.app-center.version>
 
     <!-- Used to generate default methods for POJO -->
     <org.lombok.version>1.18.2</org.lombok.version>


### PR DESCRIPTION
**ISSUE**: The dynamic calculated offset wasn't always right to give the two buckets in the esQuery result of previous and current selected period
**FIX**: Fix the offset calculating to give the right offset for esQuery params