### PR TITLE
MAINT-48842: Make the connections number of a user counted per day

### DIFF
--- a/analytics-api/src/main/java/org/exoplatform/analytics/model/filter/AnalyticsTableColumnAggregation.java
+++ b/analytics-api/src/main/java/org/exoplatform/analytics/model/filter/AnalyticsTableColumnAggregation.java
@@ -23,12 +23,14 @@ public class AnalyticsTableColumnAggregation implements Serializable, Cloneable 
 
   private boolean                    periodIndependent;
 
+  private boolean                    countDateHistogramBuckets;
+
   @Override
   public AnalyticsTableColumnAggregation clone() { // NOSONAR
     AnalyticsAggregation clonedAggregation = aggregation == null ? null : aggregation.clone();
     List<AnalyticsFieldFilter> clonedFilters = filters.stream()
                                                       .map(AnalyticsFieldFilter::clone)
                                                       .collect(Collectors.toList());
-    return new AnalyticsTableColumnAggregation(clonedAggregation, clonedFilters, periodIndependent);
+    return new AnalyticsTableColumnAggregation(clonedAggregation, clonedFilters, periodIndependent, countDateHistogramBuckets);
   }
 }

--- a/analytics-api/src/main/java/org/exoplatform/analytics/model/filter/aggregation/AnalyticsAggregation.java
+++ b/analytics-api/src/main/java/org/exoplatform/analytics/model/filter/aggregation/AnalyticsAggregation.java
@@ -73,6 +73,9 @@ public class AnalyticsAggregation implements Serializable, Cloneable {
   @Exclude
   private long                          maxBound;
 
+  @Exclude
+  private long                          minDocCount;
+
   public AnalyticsAggregation(AnalyticsAggregationType type, String field, String sortDirection, String interval, long limit) {
     super();
     this.type = type;
@@ -85,6 +88,19 @@ public class AnalyticsAggregation implements Serializable, Cloneable {
   public AnalyticsAggregation(String field) {
     this.field = field;
     this.type = AnalyticsAggregationType.TERMS;
+  }
+
+  public AnalyticsAggregation(AnalyticsAggregationType type, String field, String sortDirection, String interval, String offset, long limit, boolean useBounds, long minBound, long maxBound) {
+    super();
+    this.type = type;
+    this.field = field;
+    this.sortDirection = sortDirection;
+    this.interval = interval;
+    this.limit = limit;
+    this.offset = offset;
+    this.useBounds = useBounds;
+    this.minBound = minBound;
+    this.maxBound = maxBound;
   }
 
   public String getSortDirection() {
@@ -139,7 +155,7 @@ public class AnalyticsAggregation implements Serializable, Cloneable {
 
   @Override
   public AnalyticsAggregation clone() { // NOSONAR
-    return new AnalyticsAggregation(type, field, sortDirection, interval, offset, limit, useBounds, minBound, maxBound);
+    return new AnalyticsAggregation(type, field, sortDirection, interval, offset, limit, useBounds, minBound, maxBound, minDocCount);
   }
 
 }

--- a/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/portal/portal/global/pages.xml
+++ b/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/portal/portal/global/pages.xml
@@ -495,9 +495,12 @@
                                }
                             ],
                             "periodIndependent":false,
+                            "countDateHistogramBuckets":true,
                             "aggregation":{
-                               "sortDirection":"desc",
-                               "type":"COUNT"
+                               "field": "timestamp",
+                               "type": "DATE",
+                               "interval": "day",
+                               "minDocCount": 1
                             }
                          },
                          "sortable":true,


### PR DESCRIPTION
**ISSUE**: The user connections number is counted per connection, and as result if the user connected many times by login/logout from different devices the connections number will be incremented
**FIX**: Using date histogram aggregation to count the connections per day and consider the several login/logout per day as one connection