### PR TITLE
Task-51718 : In automatic administration page, some string are not i18n

### DIFF
--- a/analytics-webapps/src/main/webapp/vue-app/common-components/components/settings/JsonPanelDialog.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/common-components/components/settings/JsonPanelDialog.vue
@@ -18,7 +18,7 @@
           @click="dialog = false">
         </a>
         <span class="ignore-vuetify-classes PopupTitle popupTitle">
-          JSON Panel of chart <span class="primary--text">{{ settings && settings.title }}</span>
+          JSON Panel of chart <span class="primary--text">{{ settings && $t(settings.title) }}</span>
         </span>
       </div>
       <v-card-text>

--- a/analytics-webapps/src/main/webapp/vue-app/generic-portlet/components/AnalyticsApplication.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/generic-portlet/components/AnalyticsApplication.vue
@@ -18,7 +18,7 @@
         class="mt-0" />
       <analytics-view-samples-drawer
         ref="viewSamplesDrawer"
-        :title="title"
+        :title="$t(title)"
         :selected-period="selectedPeriod"
         :users="userObjects"
         :spaces="spaceObjects"


### PR DESCRIPTION
The AnalyticApplication component does not use the i18n title for the sample drawer title
The JsonPanelDialog component do not use i18n title for popup header

This commit update theses components to use i18n title if available