### PR TITLE
TASK-51770 : Probelm to display analytics whith local ar_OM (#204)

### DIFF
--- a/analytics-webapps/src/main/webapp/vue-app/common-components/components/common/SelectPeriod.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/common-components/components/common/SelectPeriod.vue
@@ -101,7 +101,7 @@ export default {
   },
   data: () => ({
     menu: false,
-    lang: eXo.env.portal.language,
+    lang: eXo.env.portal.language && eXo.env.portal.language.replace('_','-'),
     dates: [],
     fromTime: '00:00',
     toTime: '23:59',

--- a/analytics-webapps/src/main/webapp/vue-app/common-components/components/samples/ViewSamplesDrawer.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/common-components/components/samples/ViewSamplesDrawer.vue
@@ -117,7 +117,7 @@ export default {
 
       let loadedChartData;
       const params = {
-        lang: eXo.env.portal.language,
+        lang: eXo.env.portal.language && eXo.env.portal.language.replace('_','-'),
         min: this.selectedPeriod.min,
         max: this.selectedPeriod.max + 60000,
         timeZone: this.$analyticsUtils.USER_TIMEZONE_ID,

--- a/analytics-webapps/src/main/webapp/vue-app/generic-portlet/components/AnalyticsApplication.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/generic-portlet/components/AnalyticsApplication.vue
@@ -317,7 +317,7 @@ export default {
 
       this.loading = true;
       const params = {
-        lang: eXo.env.portal.language,
+        lang: eXo.env.portal.language && eXo.env.portal.language.replace('_','-'),
         min: this.selectedPeriod.min,
         max: this.selectedPeriod.max + 60000,
         timeZone: this.$analyticsUtils.USER_TIMEZONE_ID,

--- a/analytics-webapps/src/main/webapp/vue-app/rate-portlet/components/AnalyticsRateApplication.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/rate-portlet/components/AnalyticsRateApplication.vue
@@ -309,7 +309,7 @@ export default {
 
       this.loading = true;
       const params = {
-        lang: eXo.env.portal.language,
+        lang: eXo.env.portal.language && eXo.env.portal.language.replace('_','-'),
         periodType: this.selectedPeriod.period || '',
         min: this.selectedPeriod.min,
         max: this.selectedPeriod.max + 60000,

--- a/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTable.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTable.vue
@@ -257,7 +257,7 @@ export default {
           });
       } else if (!column.userField && !column.spaceField && column.valueAggregation && column.valueAggregation.aggregation) {
         const params = {
-          lang: eXo.env.portal.language,
+          lang: eXo.env.portal.language && eXo.env.portal.language.replace('_','-'),
           column: columnIndex,
           limit: String(limit || 0),
           periodType: this.period.period || '',

--- a/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTableCellDocumentTitleValue.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTableCellDocumentTitleValue.vue
@@ -53,7 +53,7 @@ export default {
       return this.attachment && this.attachment.acl && !this.attachment.acl.canAccess;
     },
     currentLanguage() {
-      return eXo && eXo.env && eXo.env.portal && eXo.env.portal.language || 'en';
+      return eXo && eXo.env && eXo.env.portal && eXo.env.portal.language.replace('_','-') || 'en';
     },
     absoluteDateModified(options) {
       return new Date(this.attachment.date).toLocaleString(this.currentLanguage, options).split('/').join('-');


### PR DESCRIPTION
Before this fix, when using locale ar_OM, graph are not display. This is due to the fact that the PortalContainer try to read lang with format ar-OM which is the standard format, but eXo.env.portal.language have format ar_OM.
As the vuejs i18n part wait for format ar_OM, this fix update the js variable when needed to send the lang with correct format