### PR TITLE
Task-51753 : ASC Sort of connections count column NOK in user analytics table

### DIFF
--- a/analytics-api/src/main/java/org/exoplatform/analytics/model/filter/AnalyticsTableColumnAggregation.java
+++ b/analytics-api/src/main/java/org/exoplatform/analytics/model/filter/AnalyticsTableColumnAggregation.java
@@ -23,14 +23,12 @@ public class AnalyticsTableColumnAggregation implements Serializable, Cloneable 
 
   private boolean                    periodIndependent;
 
-  private boolean                    countDateHistogramBuckets;
-
   @Override
   public AnalyticsTableColumnAggregation clone() { // NOSONAR
     AnalyticsAggregation clonedAggregation = aggregation == null ? null : aggregation.clone();
     List<AnalyticsFieldFilter> clonedFilters = filters.stream()
                                                       .map(AnalyticsFieldFilter::clone)
                                                       .collect(Collectors.toList());
-    return new AnalyticsTableColumnAggregation(clonedAggregation, clonedFilters, periodIndependent, countDateHistogramBuckets);
+    return new AnalyticsTableColumnAggregation(clonedAggregation, clonedFilters, periodIndependent);
   }
 }

--- a/analytics-api/src/main/java/org/exoplatform/analytics/model/filter/aggregation/AnalyticsAggregation.java
+++ b/analytics-api/src/main/java/org/exoplatform/analytics/model/filter/aggregation/AnalyticsAggregation.java
@@ -73,9 +73,6 @@ public class AnalyticsAggregation implements Serializable, Cloneable {
   @Exclude
   private long                          maxBound;
 
-  @Exclude
-  private long                          minDocCount;
-
   public AnalyticsAggregation(AnalyticsAggregationType type, String field, String sortDirection, String interval, long limit) {
     super();
     this.type = type;
@@ -88,19 +85,6 @@ public class AnalyticsAggregation implements Serializable, Cloneable {
   public AnalyticsAggregation(String field) {
     this.field = field;
     this.type = AnalyticsAggregationType.TERMS;
-  }
-
-  public AnalyticsAggregation(AnalyticsAggregationType type, String field, String sortDirection, String interval, String offset, long limit, boolean useBounds, long minBound, long maxBound) {
-    super();
-    this.type = type;
-    this.field = field;
-    this.sortDirection = sortDirection;
-    this.interval = interval;
-    this.limit = limit;
-    this.offset = offset;
-    this.useBounds = useBounds;
-    this.minBound = minBound;
-    this.maxBound = maxBound;
   }
 
   public String getSortDirection() {
@@ -155,7 +139,7 @@ public class AnalyticsAggregation implements Serializable, Cloneable {
 
   @Override
   public AnalyticsAggregation clone() { // NOSONAR
-    return new AnalyticsAggregation(type, field, sortDirection, interval, offset, limit, useBounds, minBound, maxBound, minDocCount);
+    return new AnalyticsAggregation(type, field, sortDirection, interval, offset, limit, useBounds, minBound, maxBound);
   }
 
 }

--- a/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/portal/portal/global/pages.xml
+++ b/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/portal/portal/global/pages.xml
@@ -431,7 +431,7 @@
               <preference>
                 <name>settings</name>
                 <value>{
-                   "pageSize": 20,
+                   "pageSize":20,
                    "mainColumn":{
                       "title":"analytics.users",
                       "valueAggregation":{
@@ -495,12 +495,10 @@
                                }
                             ],
                             "periodIndependent":false,
-                            "countDateHistogramBuckets":true,
                             "aggregation":{
-                               "field": "timestamp",
-                               "type": "DATE",
-                               "interval": "day",
-                               "minDocCount": 1
+                               "sortDirection":"desc",
+                               "field":"doc['timestamp'].value.dayOfYear",
+                               "type":"CARDINALITY"
                             }
                          },
                          "sortable":true,


### PR DESCRIPTION
Before this fix, the aggregation on dayOfYear was done in exo context instead of doing this in the ES request. This behaviour was added by this commit : https://github.com/exoplatform/analytics/commit/31753ae0eb1462a56d7fced7cfe595d5a460b2b9
As the aggregation shoud be counted on ES side, in the request, this commit rollback the problematic commit, and fix the initial aggregation by modifiing
doc['timestamp'].date to doc['timestamp'].value which is the correct way to use it with painless ES scripts