### PR TITLE
Task-50895: No information about the files upload by externals in the table File management analytics

### DIFF
--- a/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/dynamic-container-configuration.xml
+++ b/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/dynamic-container-configuration.xml
@@ -28,6 +28,9 @@
                 <value>
                   <string>*:/platform/users</string>
                 </value>
+                <value>
+                  <string>*:/platform/externals</string>
+                </value>
               </collection>
             </field>
             <field name="title">


### PR DESCRIPTION
Prior this change, when an external user upload a file in attachement drawer, no information added in file managment analytics. its due to missing permission
Fix: Add permission for external users