### PR TITLE
TASK-50764 : unable to change color of modules of pie chart

### DIFF
--- a/analytics-webapps/src/main/webapp/vue-app/common-components/components/settings/tabs/ColorsSettingForm.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/common-components/components/settings/tabs/ColorsSettingForm.vue
@@ -49,7 +49,7 @@ export default {
   }),
   computed: {
     multipleCharts() {
-      return this.settings && this.settings.multipleChartsField;
+      return this.settings && (this.settings.multipleChartsField || this.settings.chartType === 'pie');
     },
     chartColors() {
       if (this.multipleCharts) {


### PR DESCRIPTION
**ISSUE** : moving to the pie chart -> settings -> colors : only the first color is displayed so we cannot change the other colors because the pie chart is not a multiple chart.

**FIX** : add a condition before testing if the chart has a multiple type filed, if the chart type is `pie` so we can display the list of module colors and change it. so the pie chart is an exception because it displays many modules with different colors but it is not a multiple chart type.